### PR TITLE
.zshrc を更新

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -160,7 +160,6 @@ alias gst="git status"
 alias gd="git diff"
 alias br="git branch"
 alias ga="git add ."
-alias gh="git help"
 alias gl="git log --graph --pretty='format:%C(yellow)%h%Creset %C(magenta)%cd%Creset %s %Cgreen(%an)%Creset %Cred%d%Creset' --date=iso"
 alias glog='git log --graph --decorate --pretty=format:"%ad [%cn] <c:%h t:%t p:%p> %n %Cgreen%d%Creset %s %n" --stat -p'
 alias gls='git log --stat --summary'
@@ -198,6 +197,14 @@ function peco-history-selection() {
 }
 zle -N peco-history-selection
 bindkey '^R' peco-history-selection
+
+function pet-select() {
+  BUFFER=$(pet search --query "$LBUFFER")
+  CURSOR=$#BUFFER
+  zle redisplay
+}
+zle -N pet-select
+bindkey '^V' pet-select
 
 PATH=$PATH:$HOME/bin/flutter/bin
 


### PR DESCRIPTION
## 概要

各種ツールの追加・設定変更に伴い `.zshrc` を更新します。

## 変更内容

### .zshrc

- `alias gh="git help"` を削除（`gh` コマンド（GitHub CLI）との競合を解消）
- `pet-select` 関数を追加（`^V` でスニペット検索を呼び出す）

🤖 Generated with [Claude Code](https://claude.com/claude-code)